### PR TITLE
Fix Labels font-size

### DIFF
--- a/mobile.css
+++ b/mobile.css
@@ -104,6 +104,7 @@ h5, #detailsTrackersPage a, #detailsFilesPage a, #detailsDetailsPage #label td, 
 }
 #torrentsList .nav > li > a {
   margin-right: 1px;
+  font-size: 11px;
 }
 #torrentsList .nav > li > a > span {
   float: left;


### PR DESCRIPTION
Fixes https://github.com/xombiemp/rutorrentMobile/issues/41

Issue seems to one of the generic css selectors for .nav sets `font-size: 0`. Which is why we see non-existent label names like image posted in issue.
Testing an older rutorrent+mobile shows the labels being set to `11px` while inspecting elements.